### PR TITLE
undo/redo + bugfixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 
 ### Bugfixes
 
-* Timeline:
+* Timeline: (Fixes [#150](https://github.com/StudioProcess/rvp/issues/150))
   * Track title
     * Fix setting player head on mousedown
     * Fix triggering app hotkey handler (e.g. space) when typing new track title

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+# 0.2.0 (2017-11-27) Undo/Redo
+
+* Undo/redo feature (default: 20 actions are saved, see `src/app/config/snapshots.ts`)
+
+### Bugfixes
+
+* Timeline:
+  * Track title
+    * Fix setting player head on mousedown
+    * Fix triggering app hotkey handler (e.g. space) when typing new track title
+  * Delete track
+    * Fix setting player head on mousedown
+* Fix unnecessary handlebar update emits
+
 # 0.1.0 (2017-11-23) Refactoring Pass
 
 * Changelog init

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ Live version: http://rv.process.studio
 
 ## Development server
 
-This project was generated with [Angular CLI](https://github.com/angular/angular-cli) version 1.2.1.
+This project was generated with [Angular CLI](https://github.com/angular/angular-cli).
 
 Run `ng serve` for a dev server. Navigate to `http://localhost:4200/`. The app will automatically reload if you change any of the source files.
 

--- a/src/app/config/project.ts
+++ b/src/app/config/project.ts
@@ -1,7 +1,7 @@
 import {OutputType} from 'jszip'
 import {id} from '../lib/fp'
 
-export const _PROJECT_AUTOSAVE_DEBOUNCE_ = 1000
+export const _PROJECT_AUTOSAVE_DEBOUNCE_ = 600
 
 export const _DEFAULT_PROJECT_PATH_ = 'assets/projects/default.rv'
 

--- a/src/app/config/project.ts
+++ b/src/app/config/project.ts
@@ -1,7 +1,7 @@
 import {OutputType} from 'jszip'
 import {id} from '../lib/fp'
 
-export const _PROJECT_AUTOSAVE_DEBOUNCE_ = 600
+export const _PROJECT_AUTOSAVE_DEBOUNCE_ = 1000
 
 export const _DEFAULT_PROJECT_PATH_ = 'assets/projects/default.rv'
 

--- a/src/app/config/snapshots.ts
+++ b/src/app/config/snapshots.ts
@@ -1,1 +1,2 @@
-export const _SNAPSHOTS_MAX_STACKSIZE_ = 20
+export const _SNAPSHOTS_MAX_STACKSIZE_ = 5
+export const _SNAPSHOTS_DEBOUNCE_ = 60

--- a/src/app/config/snapshots.ts
+++ b/src/app/config/snapshots.ts
@@ -1,0 +1,1 @@
+export const _SNAPSHOTS_MAX_STACKSIZE_ = 20

--- a/src/app/config/snapshots.ts
+++ b/src/app/config/snapshots.ts
@@ -1,1 +1,1 @@
-export const _SNAPSHOTS_MAX_STACKSIZE_ = 5
+export const _SNAPSHOTS_MAX_STACKSIZE_ = 20

--- a/src/app/config/snapshots.ts
+++ b/src/app/config/snapshots.ts
@@ -1,2 +1,2 @@
 export const _SNAPSHOTS_MAX_STACKSIZE_ = 5
-export const _SNAPSHOTS_DEBOUNCE_ = 60
+export const _SNAPSHOTS_DEBOUNCE_ = 500

--- a/src/app/config/snapshots.ts
+++ b/src/app/config/snapshots.ts
@@ -1,2 +1,1 @@
 export const _SNAPSHOTS_MAX_STACKSIZE_ = 5
-export const _SNAPSHOTS_DEBOUNCE_ = 500

--- a/src/app/core/components/main/main.ts
+++ b/src/app/core/components/main/main.ts
@@ -47,7 +47,11 @@ export class MainContainer implements OnInit, OnDestroy, AfterViewInit {
     })
 
     const undoHotkey = windowKeydown.filter((e: KeyboardEvent) => {
-      return e.keyCode === 90 && e.metaKey // cmd z
+      return e.keyCode === 90 && e.metaKey && !e.shiftKey // cmd z (make sure shiftKey is not pressed)
+    })
+
+    const redoHotkey = windowKeydown.filter((e: KeyboardEvent) => {
+      return e.keyCode === 90 && e.metaKey && e.shiftKey // shift cmd z
     })
 
     const annotationSelection = this._rootStore.select(fromRoot.getAnnotationSelection).share()
@@ -92,8 +96,13 @@ export class MainContainer implements OnInit, OnDestroy, AfterViewInit {
         }))
 
     this._subs.push(
-      undoHotkey.subscribe((e: KeyboardEvent) => {
+      undoHotkey.subscribe(() => {
         this._rootStore.dispatch(new project.ProjectUndo())
+      }))
+
+    this._subs.push(
+      redoHotkey.subscribe(() => {
+        this._rootStore.dispatch(new project.ProjectRedo())
       }))
   }
 

--- a/src/app/core/components/main/main.ts
+++ b/src/app/core/components/main/main.ts
@@ -46,6 +46,10 @@ export class MainContainer implements OnInit, OnDestroy, AfterViewInit {
         e.keyCode === 171    // + (firefox)
     })
 
+    const undoHotkey = windowKeydown.filter((e: KeyboardEvent) => {
+      return e.keyCode === 90 && e.metaKey // cmd z
+    })
+
     const annotationSelection = this._rootStore.select(fromRoot.getAnnotationSelection).share()
 
     this._subs.push(
@@ -86,6 +90,11 @@ export class MainContainer implements OnInit, OnDestroy, AfterViewInit {
           this._rootStore.dispatch(new project.ProjectDeleteAnnotation(deletePayload))
           this._cdr.markForCheck()
         }))
+
+    this._subs.push(
+      undoHotkey.subscribe((e: KeyboardEvent) => {
+        this._rootStore.dispatch(new project.ProjectUndo())
+      }))
   }
 
   importProject(projectFile: File) {

--- a/src/app/core/components/main/main.ts
+++ b/src/app/core/components/main/main.ts
@@ -96,12 +96,14 @@ export class MainContainer implements OnInit, OnDestroy, AfterViewInit {
         }))
 
     this._subs.push(
-      undoHotkey.subscribe(() => {
+      undoHotkey.subscribe((e: KeyboardEvent) => {
+        e.preventDefault()
         this._rootStore.dispatch(new project.ProjectUndo())
       }))
 
     this._subs.push(
-      redoHotkey.subscribe(() => {
+      redoHotkey.subscribe((e: KeyboardEvent) => {
+        e.preventDefault()
         this._rootStore.dispatch(new project.ProjectRedo())
       }))
   }

--- a/src/app/core/components/timeline/track/track.component.html
+++ b/src/app/core/components/timeline/track/track.component.html
@@ -6,7 +6,7 @@
     <input #title class="title-input" placeholder="Track Title" title="Track Title" formControlName="title">
   </div>
   <div class="column shrink track-options">
-    <button class="ion-android-close track-delete-icon" title="Delete Track" alt="Delete Track" (click)="deleteTrackHandler()"></button>
+    <button class="ion-android-close track-delete-icon" title="Delete Track" alt="Delete Track" (mousedown)="deleteTrackHandler($event)"></button>
   </div>
 </div>
 <div class="annotations-wrapper" (dblclick)="addAnnotation($event)">

--- a/src/app/core/components/timeline/track/track.component.html
+++ b/src/app/core/components/timeline/track/track.component.html
@@ -3,7 +3,7 @@
     <div class="track-color" [style.color]="data.get('color', null)">
       <i class="ion-record" title="Track Color"></i>
     </div>
-    <input class="title-input" placeholder="Track Title" title="Track Title" formControlName="title">
+    <input #title class="title-input" placeholder="Track Title" title="Track Title" formControlName="title">
   </div>
   <div class="column shrink track-options">
     <button class="ion-android-close track-delete-icon" title="Delete Track" alt="Delete Track" (click)="deleteTrackHandler()"></button>

--- a/src/app/core/components/timeline/track/track.component.ts
+++ b/src/app/core/components/timeline/track/track.component.ts
@@ -71,8 +71,19 @@ export class TrackComponent implements OnInit, OnChanges, OnDestroy {
       title: [this.data.getIn(['fields', 'title']), Validators.required]
     })
 
+    const titleInputMd = Observable.fromEvent(this.titleInput.nativeElement, 'mousedown')
     const titleInputKeydown = Observable.fromEvent(this.titleInput.nativeElement, 'keydown')
     const formBlur = Observable.fromEvent(this.titleInput.nativeElement, 'blur')
+
+    this._subs.push(
+      titleInputMd.subscribe((ev: KeyboardEvent) => {
+        ev.stopPropagation()
+      }))
+
+    this._subs.push(
+      titleInputKeydown.subscribe((ev: KeyboardEvent) => {
+        ev.stopPropagation()
+      }))
 
     this._subs.push(
       titleInputKeydown

--- a/src/app/core/components/timeline/track/track.component.ts
+++ b/src/app/core/components/timeline/track/track.component.ts
@@ -181,7 +181,8 @@ export class TrackComponent implements OnInit, OnChanges, OnDestroy {
     return track.get('id', null)
   }
 
-  deleteTrackHandler() {
+  deleteTrackHandler(ev: MouseEvent) {
+    ev.stopPropagation()
     if(window.confirm("Really delete track? All annotations will be deleted too.")){
       this.onDeleteTrack.emit({trackIndex: this.trackIndex})
     }

--- a/src/app/core/components/timeline/track/track.component.ts
+++ b/src/app/core/components/timeline/track/track.component.ts
@@ -71,7 +71,15 @@ export class TrackComponent implements OnInit, OnChanges, OnDestroy {
       title: [this.data.getIn(['fields', 'title']), Validators.required]
     })
 
+    const titleInputKeydown = Observable.fromEvent(this.titleInput.nativeElement, 'keydown')
     const formBlur = Observable.fromEvent(this.titleInput.nativeElement, 'blur')
+
+    this._subs.push(
+      titleInputKeydown
+        .filter((ev: KeyboardEvent) => ev.keyCode === 13)
+        .subscribe((ev: any) => {
+          ev.target.blur()
+        }))
 
     this._subs.push(
       formBlur
@@ -93,7 +101,6 @@ export class TrackComponent implements OnInit, OnChanges, OnDestroy {
               annotations: this.data.get('annotations', null)
             })
           }
-
           this.onUpdateTrack.emit(updateTrackPayload)
         }))
 

--- a/src/app/persistence/actions/project.ts
+++ b/src/app/persistence/actions/project.ts
@@ -34,7 +34,6 @@ export const PROJECT_SET_TIMELINE_DURATION = '[Project] Set Timeline Duration'
 export const PROJECT_PUSH_UNDO = '[Project] Push Undo'
 export const PROJECT_UNDO = '[Project] Undo'
 export const PROJECT_REDO = '[Project] Redo'
-export const PROJECT_CLEAR_REDO = '[Project] Clear Redo'
 
 export class ProjectLoad implements Action {
   readonly type = PROJECT_LOAD
@@ -166,10 +165,6 @@ export class ProjectUndo implements Action {
   readonly type = PROJECT_UNDO
 }
 
-export class ProjectClearRedo implements Action {
-  readonly type = PROJECT_CLEAR_REDO
-}
-
 export class ProjectRedo implements Action {
   readonly type = PROJECT_REDO
 }
@@ -183,4 +178,4 @@ export type Actions =
   ProjectAddTrack|ProjectUpdateTrack|ProjectDeleteTrack|
   ProjectAddAnnotation|ProjectUpdateAnnotation|ProjectDeleteAnnotation|
   ProjectSetTimelineDuration|
-  ProjectPushUndo|ProjectUndo|ProjectRedo|ProjectClearRedo
+  ProjectPushUndo|ProjectUndo|ProjectRedo

--- a/src/app/persistence/actions/project.ts
+++ b/src/app/persistence/actions/project.ts
@@ -33,6 +33,7 @@ export const PROJECT_SET_TIMELINE_DURATION = '[Project] Set Timeline Duration'
 
 export const PROJECT_PUSH_UNDO = '[Project] Push Undo'
 export const PROJECT_UNDO = '[Project] Undo'
+export const PROJECT_CLEAR_REDO = '[Project] Clear Redo'
 
 export class ProjectLoad implements Action {
   readonly type = PROJECT_LOAD
@@ -164,6 +165,10 @@ export class ProjectUndo implements Action {
   readonly type = PROJECT_UNDO
 }
 
+export class ProjectClearRedo implements Action {
+  readonly type = PROJECT_CLEAR_REDO
+}
+
 export type Actions =
   ProjectLoad|ProjectLoadSuccess|ProjectLoadError|
   ProjectImport|
@@ -173,4 +178,4 @@ export type Actions =
   ProjectAddTrack|ProjectUpdateTrack|ProjectDeleteTrack|
   ProjectAddAnnotation|ProjectUpdateAnnotation|ProjectDeleteAnnotation|
   ProjectSetTimelineDuration|
-  ProjectPushUndo|ProjectUndo
+  ProjectPushUndo|ProjectUndo|ProjectClearRedo

--- a/src/app/persistence/actions/project.ts
+++ b/src/app/persistence/actions/project.ts
@@ -2,7 +2,7 @@ import {Action} from '@ngrx/store'
 
 import {Record} from 'immutable'
 
-import {Annotation, Track, ProjectMeta} from '../model'
+import {Annotation, Track, ProjectSnapshot} from '../model'
 
 export const PROJECT_LOAD = '[Project] Load'
 export const PROJECT_LOAD_SUCCESS = '[Project] Load Success'
@@ -156,7 +156,7 @@ export class ProjectSetTimelineDuration implements Action {
 
 export class ProjectPushUndo implements Action {
   readonly type = PROJECT_PUSH_UNDO
-  constructor(readonly payload: Record<ProjectMeta>){}
+  constructor(readonly payload: Record<ProjectSnapshot>){}
 }
 
 export type Actions =

--- a/src/app/persistence/actions/project.ts
+++ b/src/app/persistence/actions/project.ts
@@ -32,6 +32,7 @@ export const PROJECT_DELETE_TRACK = '[Project] Delete Track'
 export const PROJECT_SET_TIMELINE_DURATION = '[Project] Set Timeline Duration'
 
 export const PROJECT_PUSH_UNDO = '[Project] Push Undo'
+export const PROJECT_UNDO = '[Project] Undo'
 
 export class ProjectLoad implements Action {
   readonly type = PROJECT_LOAD
@@ -159,6 +160,10 @@ export class ProjectPushUndo implements Action {
   constructor(readonly payload: Record<ProjectSnapshot>){}
 }
 
+export class ProjectUndo implements Action {
+  readonly type = PROJECT_UNDO
+}
+
 export type Actions =
   ProjectLoad|ProjectLoadSuccess|ProjectLoadError|
   ProjectImport|
@@ -168,4 +173,4 @@ export type Actions =
   ProjectAddTrack|ProjectUpdateTrack|ProjectDeleteTrack|
   ProjectAddAnnotation|ProjectUpdateAnnotation|ProjectDeleteAnnotation|
   ProjectSetTimelineDuration|
-  ProjectPushUndo
+  ProjectPushUndo|ProjectUndo

--- a/src/app/persistence/actions/project.ts
+++ b/src/app/persistence/actions/project.ts
@@ -2,7 +2,7 @@ import {Action} from '@ngrx/store'
 
 import {Record} from 'immutable'
 
-import {Annotation, Track} from '../model'
+import {Annotation, Track, ProjectMeta} from '../model'
 
 export const PROJECT_LOAD = '[Project] Load'
 export const PROJECT_LOAD_SUCCESS = '[Project] Load Success'
@@ -30,6 +30,8 @@ export const PROJECT_UPDATE_TRACK = '[Project] Update Track'
 export const PROJECT_DELETE_TRACK = '[Project] Delete Track'
 
 export const PROJECT_SET_TIMELINE_DURATION = '[Project] Set Timeline Duration'
+
+export const PROJECT_PUSH_UNDO = '[Project] Push Undo'
 
 export class ProjectLoad implements Action {
   readonly type = PROJECT_LOAD
@@ -152,6 +154,11 @@ export class ProjectSetTimelineDuration implements Action {
   constructor(readonly payload: {duration: number}) {}
 }
 
+export class ProjectPushUndo implements Action {
+  readonly type = PROJECT_PUSH_UNDO
+  constructor(readonly payload: Record<ProjectMeta>){}
+}
+
 export type Actions =
   ProjectLoad|ProjectLoadSuccess|ProjectLoadError|
   ProjectImport|
@@ -160,4 +167,5 @@ export type Actions =
   ProjectReset|
   ProjectAddTrack|ProjectUpdateTrack|ProjectDeleteTrack|
   ProjectAddAnnotation|ProjectUpdateAnnotation|ProjectDeleteAnnotation|
-  ProjectSetTimelineDuration
+  ProjectSetTimelineDuration|
+  ProjectPushUndo

--- a/src/app/persistence/actions/project.ts
+++ b/src/app/persistence/actions/project.ts
@@ -33,6 +33,7 @@ export const PROJECT_SET_TIMELINE_DURATION = '[Project] Set Timeline Duration'
 
 export const PROJECT_PUSH_UNDO = '[Project] Push Undo'
 export const PROJECT_UNDO = '[Project] Undo'
+export const PROJECT_REDO = '[Project] Redo'
 export const PROJECT_CLEAR_REDO = '[Project] Clear Redo'
 
 export class ProjectLoad implements Action {
@@ -169,6 +170,10 @@ export class ProjectClearRedo implements Action {
   readonly type = PROJECT_CLEAR_REDO
 }
 
+export class ProjectRedo implements Action {
+  readonly type = PROJECT_REDO
+}
+
 export type Actions =
   ProjectLoad|ProjectLoadSuccess|ProjectLoadError|
   ProjectImport|
@@ -178,4 +183,4 @@ export type Actions =
   ProjectAddTrack|ProjectUpdateTrack|ProjectDeleteTrack|
   ProjectAddAnnotation|ProjectUpdateAnnotation|ProjectDeleteAnnotation|
   ProjectSetTimelineDuration|
-  ProjectPushUndo|ProjectUndo|ProjectClearRedo
+  ProjectPushUndo|ProjectUndo|ProjectRedo|ProjectClearRedo

--- a/src/app/persistence/model.ts
+++ b/src/app/persistence/model.ts
@@ -1,10 +1,16 @@
-import {List, Record} from 'immutable'
+import {List, Record, Stack} from 'immutable'
 
 // Record factories
 
+export const ProjectSnapshotsFactory = Record<ProjectSnapshots>({
+  undo: Stack<Record<ProjectMeta>>(),
+  redo: Stack<Record<ProjectMeta>>()
+})
+
 export const ProjectRecordFactory = Record<Project>({
   meta: null,
-  video: null
+  video: null,
+  snapshots: new ProjectSnapshotsFactory()
 })
 
 export const ProjectMetaRecordFactory = Record<ProjectMeta>({
@@ -55,12 +61,18 @@ export const AnnotationColorMapRecordFactory = Record<AnnotationColorMap>({
 
 export interface Project {
   readonly meta: Record<ProjectMeta>|null
-  readonly video: Blob|null
+  readonly video: Blob|null,
+  readonly snapshots: ProjectSnapshots
 }
 
 export interface ProjectMeta {
   readonly id: number|null
   readonly timeline: Record<Timeline>|null
+}
+
+export interface ProjectSnapshots {
+  readonly undo: Stack<Record<ProjectMeta>>
+  readonly redo: Stack<Record<ProjectMeta>>
 }
 
 export interface Timeline {

--- a/src/app/persistence/model.ts
+++ b/src/app/persistence/model.ts
@@ -1,4 +1,4 @@
-import {List, Record, Stack} from 'immutable'
+import {List, Record} from 'immutable'
 
 // Record factories
 
@@ -13,8 +13,8 @@ export const ProjectSnapshotRecordFactory = Record<ProjectSnapshot>({
 })
 
 export const ProjectSnapshotsRecordFactory = Record<ProjectSnapshots>({
-  undo: Stack<Record<ProjectSnapshot>>(),
-  redo: Stack<Record<ProjectSnapshot>>()
+  undo: List<Record<ProjectSnapshot>>(),
+  redo: List<Record<ProjectSnapshot>>()
 })
 
 export const ProjectRecordFactory = Record<Project>({
@@ -75,9 +75,10 @@ export interface ProjectMeta {
   readonly timeline: Record<Timeline>|null
 }
 
+// Use List as double ended queue (with unshift, shift, first)
 export interface ProjectSnapshots {
-  readonly undo: Stack<Record<ProjectSnapshot>>
-  readonly redo: Stack<Record<ProjectSnapshot>>
+  readonly undo: List<Record<ProjectSnapshot>>
+  readonly redo: List<Record<ProjectSnapshot>>
 }
 
 export interface ProjectSnapshot {

--- a/src/app/persistence/model.ts
+++ b/src/app/persistence/model.ts
@@ -75,7 +75,12 @@ export interface ProjectMeta {
   readonly timeline: Record<Timeline>|null
 }
 
-// Use List as double ended queue (with unshift, shift, first)
+/* Use List as double ended queue
+ *  - unshift: Insert first
+ *  - shift: Remove first
+ *  - first: Get first
+ *  - pop: Remove last
+ */
 export interface ProjectSnapshots {
   readonly undo: List<Record<ProjectSnapshot>>
   readonly redo: List<Record<ProjectSnapshot>>

--- a/src/app/persistence/model.ts
+++ b/src/app/persistence/model.ts
@@ -2,20 +2,25 @@ import {List, Record, Stack} from 'immutable'
 
 // Record factories
 
-export const ProjectSnapshotsFactory = Record<ProjectSnapshots>({
-  undo: Stack<Record<ProjectMeta>>(),
-  redo: Stack<Record<ProjectMeta>>()
+export const ProjectMetaRecordFactory = Record<ProjectMeta>({
+  id: null,
+  timeline: null,
+})
+
+export const ProjectSnapshotRecordFactory = Record<ProjectSnapshot>({
+  timestamp: -1,
+  state: new ProjectMetaRecordFactory()
+})
+
+export const ProjectSnapshotsRecordFactory = Record<ProjectSnapshots>({
+  undo: Stack<Record<ProjectSnapshot>>(),
+  redo: Stack<Record<ProjectSnapshot>>()
 })
 
 export const ProjectRecordFactory = Record<Project>({
   meta: null,
   video: null,
-  snapshots: new ProjectSnapshotsFactory()
-})
-
-export const ProjectMetaRecordFactory = Record<ProjectMeta>({
-  id: null,
-  timeline: null,
+  snapshots: new ProjectSnapshotsRecordFactory()
 })
 
 export const TimelineRecordFactory = Record<Timeline>({
@@ -71,8 +76,13 @@ export interface ProjectMeta {
 }
 
 export interface ProjectSnapshots {
-  readonly undo: Stack<Record<ProjectMeta>>
-  readonly redo: Stack<Record<ProjectMeta>>
+  readonly undo: Stack<Record<ProjectSnapshot>>
+  readonly redo: Stack<Record<ProjectSnapshot>>
+}
+
+export interface ProjectSnapshot {
+  readonly timestamp: number
+  readonly state: Record<ProjectMeta>
 }
 
 export interface Timeline {

--- a/src/app/persistence/reducers/project.ts
+++ b/src/app/persistence/reducers/project.ts
@@ -138,7 +138,7 @@ export function reducer(state: State = initialState, action: project.Actions): S
       const undoStack: Stack<Record<ProjectSnapshot>> = state.getIn(['snapshots', 'undo'])
       if(undoStack.size > 0) {
         const currentState = state.get('meta', null)!
-        let updatedState = state.updateIn(['snapshots', 'redo'], (redoStack: Stack<Record<ProjectSnapshot>>) => {
+        const updatedRedo = state.updateIn(['snapshots', 'redo'], (redoStack: Stack<Record<ProjectSnapshot>>) => {
           const redoRecord = ProjectSnapshotRecordFactory({
             timestamp: Date.now(),
             state: currentState
@@ -154,8 +154,9 @@ export function reducer(state: State = initialState, action: project.Actions): S
         })
 
         const snapshot = undoStack.peek()!
-        updatedState = updatedState.setIn(['snapshots', 'undo'], undoStack.pop())
-        return updatedState.set('meta', snapshot.get('state', null))
+
+        const updatedUndo = updatedRedo.setIn(['snapshots', 'undo'], undoStack.pop())
+        return updatedUndo.set('meta', snapshot.get('state', null))
       }
 
       return state

--- a/src/app/persistence/reducers/project.ts
+++ b/src/app/persistence/reducers/project.ts
@@ -2,13 +2,13 @@ import {Record, List} from 'immutable'
 
 import * as project from '../actions/project'
 
-import {_SNAPSHOTS_MAX_STACKSIZE_} from '../../config/snapshots'
+// import {_SNAPSHOTS_MAX_STACKSIZE_} from '../../config/snapshots'
 
 import {
   Project, TimelineRecordFactory, ProjectRecordFactory,
   TrackRecordFactory, TrackFieldsRecordFactory,
   AnnotationRecordFactory, AnnotationFieldsRecordFactory,
-  ProjectMetaRecordFactory, Timeline, ProjectSnapshot
+  ProjectMetaRecordFactory, Timeline, //ProjectSnapshot
 } from '../model'
 
 const initialState = new ProjectRecordFactory()
@@ -121,56 +121,58 @@ export function reducer(state: State = initialState, action: project.Actions): S
       const {trackIndex} = action.payload
       return state.deleteIn(['meta', 'timeline', 'tracks', trackIndex])
     }
-    case project.PROJECT_PUSH_UNDO: {
-      return state.updateIn(['snapshots', 'undo'], (undoList: List<Record<ProjectSnapshot>>) => {
-        if(undoList.size < _SNAPSHOTS_MAX_STACKSIZE_) {
-          // Insert first
-          return undoList.unshift(action.payload)
-        } else {
-          // Remove last, insert first
-          return undoList.pop().unshift(action.payload)
-        }
-      })
-    }
-    case project.PROJECT_UNDO: {
-      const undoList: List<Record<ProjectSnapshot>> = state.getIn(['snapshots', 'undo'])
-      if(undoList.size > 0) {
-        const snapshot = undoList.first()!
-        const updatedRedo = state.updateIn(['snapshots', 'redo'], (redoList: List<Record<ProjectSnapshot>>) => {
-          if(redoList.size < _SNAPSHOTS_MAX_STACKSIZE_) {
-            return redoList.unshift(snapshot)
-          } else {
-            return redoList.pop().unshift(snapshot)
-          }
-        })
+    // case project.PROJECT_PUSH_UNDO: {
+    //   return state.updateIn(['snapshots', 'undo'], (undoList: List<Record<ProjectSnapshot>>) => {
+    //     if(undoList.size < _SNAPSHOTS_MAX_STACKSIZE_) {
+    //       // Insert first
+    //       return undoList.unshift(action.payload)
+    //     } else {
+    //       // Remove last, insert first
+    //       return undoList.withMutations(mutableUndo => {
+    //         mutableUndo.pop().unshift(action.payload)
+    //       })
+    //     }
+    //   })
+    // }
+    // case project.PROJECT_UNDO: {
+    //   const undoList: List<Record<ProjectSnapshot>> = state.getIn(['snapshots', 'undo'])
+    //   if(undoList.size > 0) {
+    //     const snapshot = undoList.first()!
+    //     const updatedRedo = state.updateIn(['snapshots', 'redo'], (redoList: List<Record<ProjectSnapshot>>) => {
+    //       if(redoList.size < _SNAPSHOTS_MAX_STACKSIZE_) {
+    //         return redoList.unshift(snapshot)
+    //       } else {
+    //         return redoList.pop().unshift(snapshot)
+    //       }
+    //     })
 
-        const updatedUndo = updatedRedo.setIn(['snapshots', 'undo'], undoList.shift())
-        return updatedUndo.set('meta', snapshot.get('state', null))
-      }
+    //     const updatedUndo = updatedRedo.setIn(['snapshots', 'undo'], undoList.shift())
+    //     return updatedUndo.set('meta', snapshot.get('state', null))
+    //   }
 
-      return state
-    }
-    case project.PROJECT_REDO: {
-      const redoList: List<Record<ProjectSnapshot>> = state.getIn(['snapshots', 'redo'])
-      if(redoList.size > 0) {
-        const snapshot = redoList.first()!
-        const updatedUndo = state.updateIn(['snapshots', 'undo'], (undoList: List<Record<ProjectSnapshot>>) => {
-          if(undoList.size < _SNAPSHOTS_MAX_STACKSIZE_) {
-            return undoList.unshift(snapshot)
-          } else {
-            return undoList.pop().unshift(snapshot)
-          }
-        })
+    //   return state
+    // }
+    // case project.PROJECT_REDO: {
+    //   const redoList: List<Record<ProjectSnapshot>> = state.getIn(['snapshots', 'redo'])
+    //   if(redoList.size > 0) {
+    //     const snapshot = redoList.first()!
+    //     const updatedUndo = state.updateIn(['snapshots', 'undo'], (undoList: List<Record<ProjectSnapshot>>) => {
+    //       if(undoList.size < _SNAPSHOTS_MAX_STACKSIZE_) {
+    //         return undoList.unshift(snapshot)
+    //       } else {
+    //         return undoList.pop().unshift(snapshot)
+    //       }
+    //     })
 
-        const updatedRedo = updatedUndo.setIn(['snapshots', 'redo'], redoList.shift())
-        return updatedRedo.set('meta', snapshot.get('state', null))
-      }
+    //     const updatedRedo = updatedUndo.setIn(['snapshots', 'redo'], redoList.shift())
+    //     return updatedRedo.set('meta', snapshot.get('state', null))
+    //   }
 
-      return state
-    }
-    case project.PROJECT_CLEAR_REDO: {
-      return state.setIn(['snapshots', 'redo'], List())
-    }
+    //   return state
+    // }
+    // case project.PROJECT_CLEAR_REDO: {
+    //   return state.setIn(['snapshots', 'redo'], List())
+    // }
     default: {
       return state
     }

--- a/src/app/persistence/reducers/project.ts
+++ b/src/app/persistence/reducers/project.ts
@@ -8,8 +8,7 @@ import {
   Project, TimelineRecordFactory, ProjectRecordFactory,
   TrackRecordFactory, TrackFieldsRecordFactory,
   AnnotationRecordFactory, AnnotationFieldsRecordFactory,
-  ProjectMetaRecordFactory, Timeline, ProjectSnapshot,
-  ProjectSnapshotRecordFactory
+  ProjectMetaRecordFactory, Timeline, ProjectSnapshot
 } from '../model'
 
 const initialState = new ProjectRecordFactory()

--- a/src/app/persistence/reducers/project.ts
+++ b/src/app/persistence/reducers/project.ts
@@ -8,7 +8,7 @@ import {
   Project, TimelineRecordFactory, ProjectRecordFactory,
   TrackRecordFactory, TrackFieldsRecordFactory,
   AnnotationRecordFactory, AnnotationFieldsRecordFactory,
-  ProjectMetaRecordFactory, Timeline, ProjectMeta
+  ProjectMetaRecordFactory, Timeline, ProjectSnapshot
 } from '../model'
 
 const initialState = new ProjectRecordFactory()
@@ -122,7 +122,7 @@ export function reducer(state: State = initialState, action: project.Actions): S
       return state.deleteIn(['meta', 'timeline', 'tracks', trackIndex])
     }
     case project.PROJECT_PUSH_UNDO: {
-      return state.updateIn(['snapshots', 'undo'], (undoStack: Stack<Record<ProjectMeta>>) => {
+      return state.updateIn(['snapshots', 'undo'], (undoStack: Stack<Record<ProjectSnapshot>>) => {
         if(undoStack.size < _SNAPSHOTS_MAX_STACKSIZE_) {
           return undoStack.push(action.payload)
         } else {

--- a/src/app/persistence/server/ServerProxy.ts
+++ b/src/app/persistence/server/ServerProxy.ts
@@ -175,7 +175,9 @@ export class ServerProxy {
             action.type === project.PROJECT_UPDATE_TRACK ||
             action.type === project.PROJECT_ADD_TRACK ||
             action.type === project.PROJECT_DELETE_TRACK ||
-            action.type === project.PROJECT_SET_TIMELINE_DURATION
+            action.type === project.PROJECT_SET_TIMELINE_DURATION ||
+            action.type === project.PROJECT_UNDO ||
+            action.type === project.PROJECT_REDO
         })
 
       this._subs.push(

--- a/src/app/persistence/server/ServerProxy.ts
+++ b/src/app/persistence/server/ServerProxy.ts
@@ -20,7 +20,6 @@ import {
   _VIDEODATA_PATH_, _EXPORT_PROJECT_NAME_,
   _PROJECT_AUTOSAVE_DEBOUNCE_
 } from '../../config/project'
-// import {_SNAPSHOTS_DEBOUNCE_} from '../../config/snapshots'
 import {_DEFZIPOTPIONS_} from '../../config/zip'
 import {LFCache} from '../cache/LFCache'
 import {loadProject, extractProject} from '../project'
@@ -197,9 +196,9 @@ export class ServerProxy {
               action.type !== project.PROJECT_UNDO &&
               action.type !== project.PROJECT_REDO
           })
-          // .debounceTime(_SNAPSHOTS_DEBOUNCE_)
           .withLatestFrom(projectState.pairwise())
           .subscribe(([_, [prevState, __]]) => {
+            // push snapshot
             const projState = prevState.get('meta', null)!
             const snapshot = new ProjectSnapshotRecordFactory({
               timestamp: Date.now(),

--- a/src/app/persistence/server/ServerProxy.ts
+++ b/src/app/persistence/server/ServerProxy.ts
@@ -32,10 +32,6 @@ import {ProjectSnapshotRecordFactory} from '../model'
 export class ServerProxy {
   private readonly _subs: Subscription[] = []
 
-  // TODO: openProject: unzip, cache video, cache project, project load success
-  // TODO: openVideo: cache video, project load success
-  // TODO: autoSave: cache project
-
   constructor(
     private readonly _actions: Actions,
     private readonly _cache: LFCache,
@@ -194,7 +190,11 @@ export class ServerProxy {
 
       this._subs.push(
         projectUpdate
-          .filter(action => action.type !== project.PROJECT_SET_TIMELINE_DURATION)
+          .filter(action => {
+            return action.type !== project.PROJECT_SET_TIMELINE_DURATION &&
+              action.type !== project.PROJECT_UNDO &&
+              action.type !== project.PROJECT_REDO
+          })
           .debounceTime(_SNAPSHOTS_DEBOUNCE_)
           .withLatestFrom(projectState.pairwise())
           .subscribe(([_, [prevState, __]]) => {

--- a/src/app/persistence/server/ServerProxy.ts
+++ b/src/app/persistence/server/ServerProxy.ts
@@ -204,7 +204,6 @@ export class ServerProxy {
               timestamp: Date.now(),
               state: projState
             })
-            this._store.dispatch(new project.ProjectClearRedo())
             this._store.dispatch(new project.ProjectPushUndo(snapshot))
           }))
     }

--- a/src/app/persistence/server/ServerProxy.ts
+++ b/src/app/persistence/server/ServerProxy.ts
@@ -10,6 +10,7 @@ import {Subscription} from 'rxjs/Subscription'
 import 'rxjs/add/operator/withLatestFrom'
 import 'rxjs/add/operator/map'
 import 'rxjs/add/operator/share'
+import 'rxjs/add/operator/pairwise'
 
 import * as project from '../actions/project'
 import * as fromProject from '../reducers'
@@ -195,9 +196,9 @@ export class ServerProxy {
         projectUpdate
           .filter(action => action.type !== project.PROJECT_SET_TIMELINE_DURATION)
           .debounceTime(_SNAPSHOTS_DEBOUNCE_)
-          .withLatestFrom(projectState)
-          .subscribe(([action, projectData]) => {
-            const projState = projectData.get('meta', null)!
+          .withLatestFrom(projectState.pairwise())
+          .subscribe(([action, [prevState, curState]]) => {
+            const projState = prevState.get('meta', null)!
             const snapshot = new ProjectSnapshotRecordFactory({
               timestamp: Date.now(),
               state: projState

--- a/src/app/persistence/server/ServerProxy.ts
+++ b/src/app/persistence/server/ServerProxy.ts
@@ -20,7 +20,7 @@ import {
   _VIDEODATA_PATH_, _EXPORT_PROJECT_NAME_,
   _PROJECT_AUTOSAVE_DEBOUNCE_
 } from '../../config/project'
-import {_SNAPSHOTS_DEBOUNCE_} from '../../config/snapshots'
+// import {_SNAPSHOTS_DEBOUNCE_} from '../../config/snapshots'
 import {_DEFZIPOTPIONS_} from '../../config/zip'
 import {LFCache} from '../cache/LFCache'
 import {loadProject, extractProject} from '../project'
@@ -195,7 +195,7 @@ export class ServerProxy {
               action.type !== project.PROJECT_UNDO &&
               action.type !== project.PROJECT_REDO
           })
-          .debounceTime(_SNAPSHOTS_DEBOUNCE_)
+          // .debounceTime(_SNAPSHOTS_DEBOUNCE_)
           .withLatestFrom(projectState.pairwise())
           .subscribe(([_, [prevState, __]]) => {
             const projState = prevState.get('meta', null)!

--- a/src/app/persistence/server/ServerProxy.ts
+++ b/src/app/persistence/server/ServerProxy.ts
@@ -197,7 +197,7 @@ export class ServerProxy {
           .filter(action => action.type !== project.PROJECT_SET_TIMELINE_DURATION)
           .debounceTime(_SNAPSHOTS_DEBOUNCE_)
           .withLatestFrom(projectState.pairwise())
-          .subscribe(([action, [prevState, curState]]) => {
+          .subscribe(([_, [prevState, __]]) => {
             const projState = prevState.get('meta', null)!
             const snapshot = new ProjectSnapshotRecordFactory({
               timestamp: Date.now(),

--- a/src/app/persistence/server/ServerProxy.ts
+++ b/src/app/persistence/server/ServerProxy.ts
@@ -193,14 +193,16 @@ export class ServerProxy {
 
       this._subs.push(
         projectUpdate
+          .filter(action => action.type !== project.PROJECT_SET_TIMELINE_DURATION)
           .debounceTime(_SNAPSHOTS_DEBOUNCE_)
           .withLatestFrom(projectState)
-          .subscribe(([, projectData]) => {
+          .subscribe(([action, projectData]) => {
             const projState = projectData.get('meta', null)!
             const snapshot = new ProjectSnapshotRecordFactory({
               timestamp: Date.now(),
               state: projState
             })
+            this._store.dispatch(new project.ProjectClearRedo())
             this._store.dispatch(new project.ProjectPushUndo(snapshot))
           }))
     }

--- a/src/app/player/Player.ts
+++ b/src/app/player/Player.ts
@@ -52,7 +52,6 @@ export class Player implements OnDestroy {
       this._subs.push(
         playerSubj.subscribe({
           next: playerInst => {
-            console.log('new player')
             // Player is an instance of a video.js Component class, with methods from
             // mixin class EventTarget.
             // https://github.com/videojs/video.js/blob/master/src/js/component.js#L88
@@ -63,7 +62,6 @@ export class Player implements OnDestroy {
                 .withLatestFrom(playerPendingSubj)
                 .filter(([_, isPending]) => !isPending)
                 .subscribe(() => {
-                  console.log('Report')
                   const currentTime = playerInst.currentTime()
                   this._store.dispatch(new player.PlayerSetCurrentTime({currentTime}))
                 }))
@@ -116,7 +114,6 @@ export class Player implements OnDestroy {
       this._subs.push(
         this.requestCurrentTime
           .subscribe(({payload: {currentTime}}) => {
-            console.log('Req')
             playerPendingSubj.next(true)
             setCurrentTimeSubj.next(currentTime)
           }))
@@ -126,7 +123,6 @@ export class Player implements OnDestroy {
           .debounceTime(_PLAYER_TIMEUPDATE_DEBOUNCE_, animationScheduler)
           .withLatestFrom(playerSubj)
           .subscribe(([currentTime, playerInst]) => {
-            console.log('Set')
             playerPendingSubj.next(false)
             playerInst.currentTime(currentTime)
           }))

--- a/src/app/player/Player.ts
+++ b/src/app/player/Player.ts
@@ -52,6 +52,7 @@ export class Player implements OnDestroy {
       this._subs.push(
         playerSubj.subscribe({
           next: playerInst => {
+            console.log('new player')
             // Player is an instance of a video.js Component class, with methods from
             // mixin class EventTarget.
             // https://github.com/videojs/video.js/blob/master/src/js/component.js#L88
@@ -62,6 +63,7 @@ export class Player implements OnDestroy {
                 .withLatestFrom(playerPendingSubj)
                 .filter(([_, isPending]) => !isPending)
                 .subscribe(() => {
+                  console.log('Report')
                   const currentTime = playerInst.currentTime()
                   this._store.dispatch(new player.PlayerSetCurrentTime({currentTime}))
                 }))
@@ -114,6 +116,7 @@ export class Player implements OnDestroy {
       this._subs.push(
         this.requestCurrentTime
           .subscribe(({payload: {currentTime}}) => {
+            console.log('Req')
             playerPendingSubj.next(true)
             setCurrentTimeSubj.next(currentTime)
           }))
@@ -123,6 +126,7 @@ export class Player implements OnDestroy {
           .debounceTime(_PLAYER_TIMEUPDATE_DEBOUNCE_, animationScheduler)
           .withLatestFrom(playerSubj)
           .subscribe(([currentTime, playerInst]) => {
+            console.log('Set')
             playerPendingSubj.next(false)
             playerInst.currentTime(currentTime)
           }))

--- a/src/app/player/Player.ts
+++ b/src/app/player/Player.ts
@@ -60,7 +60,7 @@ export class Player implements OnDestroy {
             playerInstSubs.push(
               Observable.fromEvent(playerEventEmitter, 'timeupdate')
                 .withLatestFrom(playerPendingSubj)
-                .filter(([playerInst, isPending]) => !isPending)
+                .filter(([_, isPending]) => !isPending)
                 .subscribe(() => {
                   const currentTime = playerInst.currentTime()
                   this._store.dispatch(new player.PlayerSetCurrentTime({currentTime}))

--- a/src/index.html
+++ b/src/index.html
@@ -10,6 +10,20 @@
     <link rel="icon" type="image/x-icon" href="favicon.ico">
     <link rel="apple-touch-icon" href="touch-icon-iphone.png">
     <script>paceOptions = {ajax:true, document:true, eventLag:true, restartOnRequestAfter:2000, maxProgressPerFrame:20, initialRate:0.01, ghostTime:1000, target:'.progress'}</script>
+    <style>
+      .loading-overlay {
+        position: absolute;
+        top: 0;
+        bottom: 0;
+        right: 0;
+        left: 0;
+        display: flex;
+        flex-direction: column;
+        justify-content: center;
+        align-items: center;
+        background-color: white;
+      }
+    </style>
   </head>
   <body>
     <!-- <rv-app></rv-app> -->


### PR DESCRIPTION
See [changelog](https://github.com/StudioProcess/rvp/blob/feature/undo-redo/CHANGELOG.md).
**Hotkeys:** `cmd z` (undo) and `cmd shift z` (redo) on mac.
**Note:** redux dev tools are not useable anymore. Tool keeps a history of states itself and performs really bad with current state structure, which holds undo/redo stacks to previous states.