### PR TITLE
production source-maps

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "start": "ng serve",
     "prebuild": "gulp prep:env",
     "build": "ng build",
-    "build:prod": "ng build --prod --output-hashing none",
+    "build:prod": "ng build --prod --output-hashing none --source-map",
     "test": "ng test",
     "lint": "ng lint",
     "e2e": "ng e2e",


### PR DESCRIPTION
Use `--source-map` flag

![screenshot from 2018-08-10 17-02-19](https://user-images.githubusercontent.com/2547965/43965744-5f252b9a-9cc0-11e8-8fc6-46d3bf0be1dd.png)
